### PR TITLE
VideoPlayer: Move trivial implementations to superclass

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -249,7 +249,7 @@ public:
    * Aborts any internal reading that might be stalling main thread
    * NOTICE - this can be called from another thread
    */
-  virtual void Abort() = 0;
+  virtual void Abort() { }
 
   /*
    * Flush the demuxer, if any data is kept in buffers, this should be freed now
@@ -300,12 +300,12 @@ public:
    * Set the playspeed, if demuxer can handle different
    * speeds of playback
    */
-  virtual void SetSpeed(int iSpeed) = 0;
+  virtual void SetSpeed(int iSpeed) { }
 
   /*
    * returns the total time in msec
    */
-  virtual int GetStreamLength() = 0;
+  virtual int GetStreamLength() { return 0; }
 
   /*
    * returns the stream or NULL on error
@@ -322,7 +322,7 @@ public:
   /*
    * returns opened filename
    */
-  virtual std::string GetFileName() = 0;
+  virtual std::string GetFileName() { return ""; }
 
   /*
    * return nr of subtitle streams, 0 if none

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
@@ -61,7 +61,6 @@ public:
   void Flush() override;
   DemuxPacket* Read() override;
   bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override { return false; }
-  void SetSpeed(int iSpeed) override {};
   int GetStreamLength() override { return (int)m_header.durationMs; }
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -32,16 +32,12 @@ public:
   ~CDVDDemuxCC() override;
 
   void Reset() override {};
-  void Abort() override {};
   void Flush() override {};
   DemuxPacket* Read() override { return NULL; };
   bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override {return true;};
-  void SetSpeed(int iSpeed) override {};
-  int GetStreamLength() override {return 0;};
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;
-  std::string GetFileName() override {return "";};
 
   DemuxPacket* Read(DemuxPacket *packet);
   static void Handler(int service, void *userdata);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -42,8 +42,7 @@ public:
   void Flush() override;
   DemuxPacket* Read() override;
   bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
-  void SetSpeed(int iSpeed) override {};
-  int GetStreamLength() override ;
+  int GetStreamLength() override;
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -43,7 +43,6 @@ public:
   DemuxPacket* Read() override;
   bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
   void SetSpeed(int iSpeed) override;
-  int GetStreamLength() override { return 0; }
   CDemuxStream* GetStream(int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -35,19 +35,17 @@ public:
   CDVDDemuxVobsub();
   ~CDVDDemuxVobsub() override;
 
+  bool Open(const std::string& filename, int source, const std::string& subfilename);
+
+  // implementation of CDVDDemux
   void          Reset() override;
-  void          Abort() override {};
   void          Flush() override;
   DemuxPacket*  Read() override;
   bool SeekTime(double time, bool backwards, double* startpts = NULL) override;
-  void          SetSpeed(int speed) override {}
   CDemuxStream* GetStream(int index) const override { return m_Streams[index]; }
   std::vector<CDemuxStream*> GetStreams() const override;
   int           GetNrOfStreams() const override { return m_Streams.size(); }
-  int           GetStreamLength() override    { return 0; }
-  std::string   GetFileName() override        { return m_Filename; }
-
-  bool                  Open(const std::string& filename, int source, const std::string& subfilename);
+  std::string   GetFileName() override { return m_Filename; }
   void EnableStream(int id, bool enable) override;
 
 private:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
@@ -45,22 +45,21 @@ class CDemuxMultiSource : public CDVDDemux
 public:
   CDemuxMultiSource();
   ~CDemuxMultiSource() override;
-  
+
+  bool Open(CDVDInputStream* pInput);
+
+  // implementation of CDVDDemux
   void Abort() override;
   void EnableStream(int64_t demuxerId, int id, bool enable) override;
   void Flush() override;
-  std::string GetFileName() override { return ""; };
   int GetNrOfStreams() const override;
-  CDemuxStream* GetStream(int iStreamId)const override { return nullptr; } ;
   CDemuxStream* GetStream(int64_t demuxerId, int iStreamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   std::string GetStreamCodecName(int64_t demuxerId, int iStreamId) override;
   int GetStreamLength() override;
-  bool Open(CDVDInputStream* pInput);
   DemuxPacket* Read() override;
   void Reset() override;
   bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
-  void SetSpeed(int iSpeed) override {};
 
 private:
   void Dispose();


### PR DESCRIPTION
This moves the functions addressed by #12250 to the superclass